### PR TITLE
Added enabling of 1-wire protocol to setup script

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -7,19 +7,17 @@ This README is also available in [German ![Germany](https://raw.githubuserconten
 
 ## Key features
 
--   Runs on Raspberry PI ([compatibile PIs](#compatibility)).
--   Free, do-the-fuck-you-want Open Source license (MIT).
+-   Runs on Raspberry Pi ([compatible Pis](#compatibility))
+-   Free, do-the-fuck-you-want Open Source license (MIT)
 -   Easy to setup (one liner)
--   Simple: One senor, one relay.
--   PD-Controller that works with simple and cheap non PWM/SSR relay that require
-    cooling and eliminates overshoots.
--   Modes for mashing and fermentation.
--   Multi-Language (German, English, pull-requests welcome).
+-   Simple: one sensor, one relay
+-   PD controller that works with a simple and cheap non PWM/SSR relay and yet eliminates temperature overshoots
+-   Modes for mashing and fermentation
+-   Multi-language (German, English, pull-requests welcome)
 -   Integreated recipes: Set the temperature, the time, etc.
--   Integerated logging: See your temperature log during the mash and export a PDF after brewing.
--   Authentication.
--   Works perfect on any iPhone, Android, Windows, Mac, Ubuntu system - or on
-    the Raspberry Pi.
+-   Integerated logging: See your temperature log during the mash and export a PDF after brewing
+-   Authentication
+-   Works perfectly on any web browser
 
 ## Screenshots
 
@@ -40,35 +38,31 @@ This README is also available in [German ![Germany](https://raw.githubuserconten
 ### Prepare SD-Card and Raspberry Pi
 
 1.  Download RASPBIAN BUSTER LITE from the [official website](https://www.raspberrypi.org/downloads/raspbian/).
-    Recommended version is from February 2020 (Release Date 2002-02-13), with
-    kernel version 4.19.
-2.  Flash it to the SD-Card as described on the [setup page](https://www.raspberrypi.org/documentation/installation/installing-images/)
-3.  Connect at least an (micro) HDMI Cable (Monitor), USB-Keyboard and microUSB
-    (USB-C) for Power to your RaspberryPi (4). Wait for it to boot twice.
-4.  Login using user `pi` and password `raspberry`
-5.  Run (=type) `sudo raspi-config`,
+    Recommended version is from February 2020 (Release Date 2020-02-13), with kernel version 4.19.
+1.  Flash it to the SD card as described on the [setup page](https://www.raspberrypi.org/documentation/installation/installing-images/)
+1.  Connect at least an (micro) HDMI cable (monitor), USB keyboard and microUSB
+    (USB-C) for power to your Raspberry Pi (4). Wait for it to boot twice.
+1.  Login using user `pi` and password `raspberry`
+1.  Run (=type) `sudo raspi-config`,
     1.  select `5 Interfacing Options` > `P2 SSH` and confirm with `<yes>`
-    2.  select `5 Interfacing Options` > `P7 1-Wire` and confirm with `<yes>`
-    3.  _Optional_: If you want to connect to your WiFi: now is your time:
+    1.  _Optional_: If you want to connect to your WiFi: now is your time:
         select `2 Network options` > `N2 Wifi`. This is also possible via the
         BierBot Software later.
-    4.  Also _optional_ but **recommended**: `1 Change user password`.
-6.  You may now unplug your HDMI and keyboard and operate the RaspberryPi soley
-    over Ethernet / WiFi.
-7.  Connect to your router to figure out the IP of your RaspberryPi.
+    1.  Also _optional_ but **recommended**: `1 Change user password`.
+1.  You may now unplug your HDMI and keyboard and operate the Raspberry Pi soley over Ethernet / WiFi.
+1.  Connect to your router to figure out the IP of your Raspberry Pi.
 
 ### Install the BierBot software
 
-Now, we are ready to update the RaspberryPi and install all requirements, such as NodeJS and the database which is the promised **one-liner**.
+Now, we are ready to update the Raspberry Pi and install all requirements, such as NodeJS and the database which is the promised **one-liner**.
 
 ```bash
 cd ~ && wget https://raw.githubusercontent.com/BernhardSchlegel/BierBot/master/bierbot-setup.sh && chmod +x bierbot-setup.sh && sudo ./bierbot-setup.sh
 ```
 
-**Congrats**, you're done.
+**Congrats**, you're done. Your BierBot is now accessible at http://BierBotBen (you can change the name of your BierBot on the configuration page)
 
-If you want to know what the script does in the background, check out the
-(potentially outdated) explanation [here](/doc/SETUP_MANUAL.MD).
+If you want to know what the script does in the background, check out the (potentially outdated) explanation [here](/doc/SETUP_MANUAL.MD).
 
 
 ## Compatibility

--- a/bierbot-setup.sh
+++ b/bierbot-setup.sh
@@ -5,9 +5,8 @@ if [ "$EUID" -ne 0 ]
   exit
 fi
 
-echo upgrading operating system...
+echo updating package lists...
 sudo apt-get update -y
-sudo apt-get dist-upgrade -y
 
 echo installing mongodb...
 sudo apt-get install mongodb-server -y
@@ -63,5 +62,10 @@ echo trying to bring wlan0 interface up.
 sudo ifconfig wlan0 up
 echo an error above is OK when you dont have an wifi adapter
 
-echo You may want to restart now: sudo restart -r now
+echo enabling 1-wire protocol
+if ! grep -q dtoverlay=w1-gpio /boot/config.txt; then echo dtoverlay=w1-gpio,gpiopin=4,pullup=on | sudo tee -a /boot/config.txt > /dev/null; fi
+if ! grep -q w1-gpio /etc/modules; then echo w1-gpio | sudo tee -a /etc/modules > /dev/null; fi
+if ! grep -q w1-therm /etc/modules; then echo w1-therm | sudo tee -a /etc/modules > /dev/null; fi
+
+echo You may want to restart now: sudo reboot now
 echo BierBot says: gut Sud!

--- a/doc/README_DE.MD
+++ b/doc/README_DE.MD
@@ -7,20 +7,20 @@ This README is also available in [English ![English](https://raw.githubuserconte
 
 ## Funktionen
 
--   Läuft auf dem RaspberryPi ([kompatibile PIs](#kompatiblität)).
--   Komplett freie, Open Source Lizenz (MIT).
--   Einfache Installation (Einzeiler).
--   Simpel: Ein Sensor, ein Relais.
--   PD-Controller der auch mit einfachen, günstigen Standard-Relais funktioniert
-    und dennoch effektiv das Überschiessen der Temperatur vermeidet.
--   Modi für Maischen und Gärung.
+-   Läuft auf dem Raspberry Pi ([kompatibile Pis](#kompatiblität))
+-   Komplett freie, Open Source Lizenz (MIT)
+-   Einfache Installation (Einzeiler)
+-   Simpel: Ein Sensor, ein Relais
+-   PD-Controller, der auch mit einfachen, günstigen Standard-Relais funktioniert
+    und dennoch effektiv das Überschiessen der Temperatur vermeidet
+-   Modi für Maischen und Gärung
 -   Multilingual (Deutsch, Englisch, Pull-Requests für weitere Sprachen sind
-    willkommen).
--   Integrierte Rezeptverwaltung: Rastdauer, -temperatur und Rührwerkskonfiguration.
+    willkommen)
+-   Integrierte Rezeptverwaltung: Rastdauer, -temperatur und Rührwerkskonfiguration
 -   Integriertes Logging: Der Temperaturverlauf wird während dem Brauen angezeigt,
     nach dem Brauvorgang gibt's einen Braubericht.
--   Passwortschutz (beta).
--   Läuft auf jedem iPhone, Android, Windows, Mac, Ubuntu und Raspberry Pi.
+-   Passwortschutz (beta)
+-   Läuft auf jedem Webbrowser
 
 ## Screenshots
 
@@ -68,11 +68,11 @@ Jetzt kannst du die BierBot Software installieren. Hier, wie versprochen, der
 cd ~ && wget https://raw.githubusercontent.com/BernhardSchlegel/BierBot/master/bierbot-setup.sh && chmod +x bierbot-setup.sh && sudo ./bierbot-setup.sh
 ```
 
-**Glückwunsch**, das wars.
+**Glückwunsch**, das wars. Dein BierBot ist jetzt unter http://BierBotBen erreichbar (du kannst den Namen deines BierBots auf der Konfigurationsseite ändern)
 
 ## Kompatiblität
 
-Die folgende Tabelle gibt eine Übersicht auf welchen Rasberry Pis die
+Die folgende Tabelle gibt eine Übersicht auf welchen Raspberry Pis die
 BierBot Software funktioniert ([source](https://de.wikipedia.org/wiki/Raspberry_Pi)):
 
 <table>
@@ -157,7 +157,7 @@ Standardmäßig muss der BierBot wie folgt verkabel werden (ich werde mich an de
 
 ![BierBot Wiring](/doc/img/wiring.png)
 
-- Der [DS18B20](https://amzn.to/2TQrvxQ) sensor muss mit 3,3V, GND und Pin
+- Der [DS18B20](https://amzn.to/2TQrvxQ) Sensor muss mit 3,3V, GND und Pin
   Nummer RPi 7 (pi-gpio 7) verbunden werden. Das ist der Datenkanal des
   Temperatur-Sensors.
 - Der Daten-Pin deines Relais muss mit Pin 11 (17) verbunden werden. Damit wird
@@ -169,7 +169,7 @@ Standardmäßig muss der BierBot wie folgt verkabel werden (ich werde mich an de
 - Pin 13 (27) is *optional*: Wenn der Temperatursensor nach dem Sart des
   BierBots ein- und ausgesteckt werden können soll, musst du diesen Pin verbinden.
   So wird eine ISR getriggert, die auf beiden Flanken (steigend und fallend) nach
-  neuen Temperatur sensoren sucht. Intern ist dieser Pin mit einem
+  neuen Temperatursensoren sucht. Intern ist dieser Pin mit einem
   Pulldown-Widerstand auf ground gezogen.
 - Pin 15 (22) ist ebenfalls *optional*: Hier kannst du einen [piezzo buzzer](https://amzn.to/2vDWe9D) anschließen. Der BierBot signalisiert dann mit einer
   Pieps-Symphonie, wenn der nächste Schritt erreicht wird, oder der Brauvorgang


### PR DESCRIPTION
I understand that you want to make it as simple as possible for users that might be new to the Raspberry Pi or the command line. So I thought the enabling of the 1-wire protocol could also be done through the setup script.
Since I do a lot of technical writing I couldn't stop myself changing a few more things in the README files...